### PR TITLE
Add Firebase deployment action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,52 @@
+name: Deploy Hugo website
+on:
+  push:
+    branches:
+      - master
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image: archlinux:latest
+
+    steps:
+    - name: Prepare the build environment
+      run: pacman -Syu tree hugo git --noconfirm
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+
+    # Uses the build.sh script to create `api/v?/` endpoint
+    - name: Build the website
+      run: ./build.sh
+
+    - name: Archive Production Artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: prod
+        path: public
+  
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: prod
+          path: public
+
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# chiudiamo-il-cerchio-blog
+# Chiudiamo il cerchio!
+
+![Build Hugo website](https://github.com/adic-umbria/chiudiamo-il-cerchio-blog/workflows/Build%20Hugo%20website/badge.svg)
+![Deploy Hugo website](https://github.com/adic-umbria/chiudiamo-il-cerchio-blog/workflows/Deploy%20Hugo%20website/badge.svg)
+
 Il progetto nasce con l’intento di diffondere una cultura dell'economia circolare.


### PR DESCRIPTION
### Overview

Allows continuous deployment via GitHub Actions. The website is built and deployed using `firebase-tool`.