### PR TITLE
Bump API to V1 before app release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 # Config:
 # Update `API_VERSION` when values are going to change
 API_SLUG="api"
-API_VERSION="0"
+API_VERSION="1"
 
 # Clear 'public' folder
 if [[ -d "public" ]]


### PR DESCRIPTION
### Overview

Pages are available at `https://chiudiamo-il-cerchio.web.app/api/v1/pages/index.json`. This is a breaking change for the [Alpha version of the app](https://github.com/adic-umbria/chiudiamo-il-cerchio-flutter)